### PR TITLE
[Fix] Movement On Pause

### DIFF
--- a/Assets/Scenes/Testing/RodasTestingScene.unity
+++ b/Assets/Scenes/Testing/RodasTestingScene.unity
@@ -264,6 +264,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 64395468688155716, guid: 8586a14caeea28f469cb2f682b8c1d7a, type: 3}
+      propertyPath: gameStatus
+      value: 
+      objectReference: {fileID: 11400000, guid: ee0d77ab62d6e3746a738852027b9d50, type: 2}
     - target: {fileID: 2082384582989012206, guid: 8586a14caeea28f469cb2f682b8c1d7a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/Scripts/Player/Movement.cs
+++ b/Assets/Scripts/Player/Movement.cs
@@ -18,6 +18,7 @@ namespace Scripts.Player
 
         private Vector2 movement = Vector2.zero;
         private Vector2 lastDirection;
+        private float minMovementValue = 0.01f;
 
         #endregion
 
@@ -33,26 +34,23 @@ namespace Scripts.Player
 
         private void Update()
         {
-            if (status.IsCapableOfMovement() && !gameStatus.IsPaused)
-            {
+            if ( canMove() )
                 getInputMovement();
 
-                status.SetMovingStatus(isMoving());
-            }
-            else
-                status.SetMovingStatus(false);
+            status.SetMovingStatus( isMoving() );
         }
 
         private void FixedUpdate()
         {
-            move();
+            if ( canMove() )
+                move();
+            else
+                rb.linearVelocity = Vector2.zero;
         }
 
         #endregion
 
         #region Private Methods
-
-        private bool isMoving() => (movement.normalized).sqrMagnitude > 0.01f;
 
         private void getInputMovement()
         {
@@ -66,7 +64,7 @@ namespace Scripts.Player
 
             rb.linearVelocity = normalizedMovement * speed.GetCurrentSpeed();
 
-            if (isMoving())
+            if ( isMoving() )
             {
                 lastDirection = normalizedMovement;
                 rotate();
@@ -79,6 +77,10 @@ namespace Scripts.Player
 
             rb.rotation = angle;
         }
+
+        private bool isMoving() => (movement.normalized).sqrMagnitude > minMovementValue;
+
+        private bool canMove() => status.IsCapableOfMovement() || !gameStatus.IsPaused;
 
         #endregion
     }

--- a/Assets/Scripts/Player/Weapon.cs
+++ b/Assets/Scripts/Player/Weapon.cs
@@ -1,3 +1,4 @@
+using Scripts.Scriptables;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -6,6 +7,8 @@ namespace Scripts.Player
     public class Weapon : MonoBehaviour
     {
         #region Private Variables
+
+        [SerializeField] private GameStatus gameStatus;
 
         [Header("Layer Masks")]
 
@@ -60,11 +63,14 @@ namespace Scripts.Player
 
         private void Update()
         {
-            moveAroundPlayerByMousePos(out Vector3 direction);
-            rotateToMouseDirection(direction);
+            if ( !gameStatus.IsPaused )
+            {
+                moveAroundPlayerByMousePos(out Vector3 direction);
+                rotateToMouseDirection(direction);
 
-            lightDownwardDir = - light.up;
-            detectEnemiesOnLight();
+                lightDownwardDir = -light.up;
+                detectEnemiesOnLight();
+            }
         }
 
         private void OnDrawGizmosSelected()


### PR DESCRIPTION
Player and Weapon movement will now only move if game is not paused. Player can also now NOT move if it cannot do it outside of pause interference for Cutscenes or Dialogue parts